### PR TITLE
Add Let's Encrypt certificate support via certbot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update \
       python3 python3-venv \
       iproute2 isc-dhcp-client openssl iptables \
       procps iputils-ping traceroute tcpdump whois dnsutils net-tools \
-      ca-certificates \
+      ca-certificates certbot \
  && rm -rf /var/lib/apt/lists/*
 
 # Python deps in an isolated venv (Debian bookworm is PEP-668 "externally

--- a/backend/app.py
+++ b/backend/app.py
@@ -29,6 +29,7 @@ import docker_reconcile
 import failover
 import firewall
 import health
+import letsencrypt as le
 import metrics
 import net_detect
 import net_settings
@@ -42,6 +43,7 @@ from validators import (
     clean_backend_pool,
     clean_cidr_list,
     clean_domain,
+    clean_email,
     clean_fw_action,
     clean_fw_direction,
     clean_fw_protocol,
@@ -1156,7 +1158,8 @@ def ssl_list():
 @app.post("/api/ssl/certs")
 @require_role("admin", "creator")
 def ssl_create():
-    """Add a managed certificate: upload a cert+key, or generate a self-signed."""
+    """Add a managed certificate: upload a cert+key, generate a self-signed one,
+    or request one from Let's Encrypt (HTTP-01, via certbot)."""
     form = request.form
     mode = (form.get("mode") or "").strip().lower()
     try:
@@ -1167,6 +1170,8 @@ def ssl_create():
         return _err(f"A certificate named {name} already exists.")
 
     steps = []
+    cert_bytes = key_bytes = None   # set when this branch needs the generic save below
+    extra_meta = {}
     if mode == "upload":
         cert_file = request.files.get("cert")
         key_file = request.files.get("key")
@@ -1187,18 +1192,62 @@ def ssl_create():
         if not step["ok"]:
             return _err(step["detail"], code=500, steps=steps)
         source = "selfsigned"
+    elif mode == "letsencrypt":
+        try:
+            email = clean_email(form.get("email"))
+            bind_ip = clean_ip(form.get("bind_ip"), "HTTP-01 bind IP") if form.get("bind_ip") else None
+            extra_domains = [clean_domain(d) for d in
+                             (form.get("extra_domains") or "").split(",") if d.strip()]
+        except ValidationError as exc:
+            return _err(str(exc))
+        staging = _truthy(form.get("staging"))
+
+        ok, le_steps = le.request_certificate(
+            name, email, bind_ip, extra_domains=extra_domains, staging=staging)
+        steps.extend(le_steps)
+        if not ok:
+            return _err("Could not obtain the Let's Encrypt certificate — see the step log.",
+                        code=502, steps=steps)
+        source = "letsencrypt"
+        extra_meta = {"email": email, "bind_ip": bind_ip, "staging": staging,
+                     "domains": [name] + extra_domains}
     else:
-        return _err("Choose 'upload' or 'selfsigned'.")
+        return _err("Choose 'upload', 'selfsigned' or 'letsencrypt'.")
 
-    _c, _k, res = nm.save_certificate(name, cert_bytes, key_bytes)
-    steps.append(res)
-    if not res["ok"]:
-        return _err(res["detail"], code=500, steps=steps)
+    if cert_bytes is not None:   # letsencrypt already saved its own cert files
+        _c, _k, res = nm.save_certificate(name, cert_bytes, key_bytes)
+        steps.append(res)
+        if not res["ok"]:
+            return _err(res["detail"], code=500, steps=steps)
 
-    rec = {"name": name, "source": source, "created": _now(), **nm.cert_info(name)}
+    rec = {"name": name, "source": source, "created": _now(), **extra_meta, **nm.cert_info(name)}
     storage.cert_add(rec)
     _audit("ssl.create", target=name, detail=source)
     return jsonify({"ok": True, "cert": {**rec, "in_use": False}, "steps": steps})
+
+
+@app.post("/api/ssl/certs/<name>/renew")
+@require_role("admin", "creator")
+def ssl_renew(name):
+    """Force-renew a Let's Encrypt certificate."""
+    try:
+        name = clean_domain(name)
+    except ValidationError as exc:
+        return _err(str(exc))
+    rec = storage.cert_get(name)
+    if not rec:
+        return _err("No such certificate.", code=404)
+    if rec.get("source") != "letsencrypt":
+        return _err("Only Let's Encrypt certificates can be renewed.")
+
+    ok, steps = le.renew_certificate(name, bind_ip=rec.get("bind_ip"))
+    if not ok:
+        return _err("Renewal failed — see the step log.", code=502, steps=steps)
+
+    rec = {**rec, **nm.cert_info(name), "renewed": _now()}
+    storage.cert_add(rec)
+    _audit("ssl.renew", target=name)
+    return jsonify({"ok": True, "cert": {**rec, "in_use": storage.cert_in_use(name)}, "steps": steps})
 
 
 @app.delete("/api/ssl/certs/<name>")
@@ -1208,15 +1257,18 @@ def ssl_delete(name):
         name = clean_domain(name)
     except ValidationError as exc:
         return _err(str(exc))
-    if not storage.cert_get(name):
+    rec = storage.cert_get(name)
+    if not rec:
         return _err("No such certificate.", code=404)
     if storage.cert_in_use(name):
         return _err(f"Certificate {name} is in use by a mapping — change that "
                     "mapping's SSL to none/another cert first.")
-    step = nm.remove_certificate(name)
+    steps = [nm.remove_certificate(name)]
+    if rec.get("source") == "letsencrypt":
+        steps.append(le.delete_certbot_data(name))
     storage.cert_remove(name)
     _audit("ssl.delete", target=name)
-    return jsonify({"ok": True, "steps": [step]})
+    return jsonify({"ok": True, "steps": steps})
 
 
 # --------------------------------------------------------------------------
@@ -2330,6 +2382,7 @@ if __name__ == "__main__":
     docker_reconcile.start_scheduler()  # keep docker-backed backends' IPs current (poll)
     docker_events.start_watcher()       # + react instantly to Docker events (Traefik-style)
     firewall.sync_all()        # re-apply per-interface iptables rules (self-healing on boot)
+    le.start_scheduler()       # auto-renew Let's Encrypt certs nearing expiry
     mode = "SIMULATION (no system commands executed)" if config.SIMULATE else "LIVE"
     print(f" * Splitter starting in {mode} mode")
     print(f" * stream.d : {config.STREAM_CONF_DIR}")

--- a/backend/config.py
+++ b/backend/config.py
@@ -154,6 +154,18 @@ WAF_UPSTREAM = os.environ.get(
     "SPLITTER_WAF_UPSTREAM",
     "127.0.0.1:" + os.environ.get("SPLITTER_PORT", "8088"))
 
+# --- Let's Encrypt (certbot) ----------------------------------------------
+# HTTP-01 only: certbot's --standalone authenticator binds the challenge
+# directly on the mapping's own bind IP:80, so no nginx webroot wiring is
+# needed. The issued cert is copied into SSL_DIR alongside uploaded/self-signed
+# ones, so every other code path (render_conf, the mapping form's cert picker,
+# …) treats it identically regardless of how it got there.
+CERTBOT_BIN = os.environ.get("SPLITTER_CERTBOT_BIN", "certbot")
+LETSENCRYPT_STAGING_DEFAULT = _env_bool("SPLITTER_LETSENCRYPT_STAGING", False)
+# Re-checked periodically; a cert is renewed once it's within this many days
+# of expiring (mirrors certbot's/Let's Encrypt's own 30-day guidance).
+LETSENCRYPT_RENEW_WITHIN_DAYS = int(os.environ.get("SPLITTER_LETSENCRYPT_RENEW_DAYS", "30"))
+
 # Prefix used for privileged commands. Empty when already running as root
 # (the systemd unit sets SPLITTER_SUDO=""); falls back to "sudo" otherwise.
 SUDO = os.environ.get("SPLITTER_SUDO", "" if os.geteuid() == 0 else "sudo")
@@ -225,4 +237,5 @@ def as_dict():
         "default_backend": DEFAULT_BACKEND,
         "listen_port": LISTEN_PORT,
         "simulate": SIMULATE,
+        "letsencrypt_staging_default": LETSENCRYPT_STAGING_DEFAULT,
     }

--- a/backend/letsencrypt.py
+++ b/backend/letsencrypt.py
@@ -1,0 +1,206 @@
+"""
+Let's Encrypt certificate issuance via certbot — HTTP-01 challenge only.
+
+certbot's `--standalone` authenticator binds the ACME challenge directly on
+the mapping's bind IP, port 80, for the few seconds the request takes — no
+nginx webroot/vhost wiring needed. Once certbot succeeds, the issued
+fullchain/privkey are copied into config.SSL_DIR under the same
+`<name>.crt` / `<name>.key` naming every other certificate source
+(upload, self-signed) already uses, so nginx_manager's render_conf /
+render_http_conf need no changes to serve a Let's Encrypt cert.
+
+Renewal runs on a background thread (see start_scheduler), mirroring
+backup.py's scheduler: check periodically, renew anything within
+config.LETSENCRYPT_RENEW_WITHIN_DAYS of expiring.
+"""
+import datetime
+import os
+import threading
+import time
+
+import config
+import nginx_manager as nm
+import storage
+from nginx_manager import StepResult
+
+
+def _live_dir(domain):
+    return f"/etc/letsencrypt/live/{domain}"
+
+
+def _read_issued(domain):
+    """(cert_bytes, key_bytes) from certbot's live directory."""
+    live = _live_dir(domain)
+    with open(os.path.join(live, "fullchain.pem"), "rb") as fh:
+        cert_bytes = fh.read()
+    with open(os.path.join(live, "privkey.pem"), "rb") as fh:
+        key_bytes = fh.read()
+    return cert_bytes, key_bytes
+
+
+def _install_issued(domain, steps):
+    """Copy the certbot-issued (or, in SIMULATE, a demo self-signed) cert into
+    SSL_DIR via the same path every other cert source uses. Appends its own
+    StepResult(s) to `steps` and returns True/False."""
+    if config.SIMULATE:
+        # certbot never actually ran (no network, no root, no real DNS) — but
+        # openssl runs fine locally, so generate a stand-in cert the same way
+        # the self-signed flow already does, purely so the UI has something
+        # real to show. Clearly labelled so it's never mistaken for a live cert.
+        cert_bytes, key_bytes, gen_step = nm.generate_self_signed(domain)
+        gen_step["detail"] = "[simulated — no real ACME order was made] " + gen_step["detail"]
+        gen_step["simulated"] = True
+        steps.append(gen_step)
+        if not gen_step["ok"]:
+            return False
+    else:
+        try:
+            cert_bytes, key_bytes = _read_issued(domain)
+        except OSError as exc:
+            steps.append(StepResult("Read issued certificate", False, str(exc)))
+            return False
+
+    _c, _k, save_step = nm.save_certificate(domain, cert_bytes, key_bytes)
+    steps.append(save_step)
+    return save_step["ok"]
+
+
+def _certbot_args(domain, email, extra_domains, bind_ip, staging):
+    domains = [domain] + [d for d in (extra_domains or []) if d and d != domain]
+    args = [
+        config.CERTBOT_BIN, "certonly", "-n", "--agree-tos", "--no-eff-email",
+        "-m", email,
+        "--standalone",
+        "--preferred-challenges", "http",
+        "--http-01-port", "80",
+        "--cert-name", domain,
+        "-d", ",".join(domains),
+    ]
+    if bind_ip:
+        args += ["--http-01-address", bind_ip]
+    if staging:
+        args.append("--staging")
+    return args
+
+
+def request_certificate(domain, email, bind_ip, extra_domains=None, staging=False):
+    """Request a new certificate. Returns (ok, steps)."""
+    steps = []
+
+    if not config.SIMULATE:
+        if not bind_ip:
+            steps.append(StepResult(
+                "Check HTTP-01 bind address", False,
+                "No bind IP given — pick the address that this domain's DNS "
+                "points at, so Let's Encrypt can reach the challenge on port 80."))
+            return False, steps
+        if nm.is_listening(bind_ip, 80):
+            steps.append(StepResult(
+                "Check port 80", False,
+                f"{bind_ip}:80 is already in use — free it (disable whatever's "
+                "bound there) before requesting a certificate; the HTTP-01 "
+                "challenge needs that port for a few seconds."))
+            return False, steps
+
+    args = _certbot_args(domain, email, extra_domains, bind_ip, staging)
+    res = nm.run_cmd("Request Let's Encrypt certificate (certbot)", nm._privileged(args))
+    steps.append(res)
+    if not res["ok"]:
+        return False, steps
+
+    return _install_issued(domain, steps), steps
+
+
+def renew_certificate(domain, bind_ip=None):
+    """Force-renew an existing certificate. Returns (ok, steps).
+
+    certbot remembers the authenticator/domains/address from the original
+    request (saved under /etc/letsencrypt/renewal/), so `renew` only needs the
+    cert name — but the HTTP-01 port-80 requirement is the same as issuance.
+    """
+    steps = []
+    if not config.SIMULATE and bind_ip and nm.is_listening(bind_ip, 80):
+        steps.append(StepResult(
+            "Check port 80", False,
+            f"{bind_ip}:80 is already in use — free it before renewing."))
+        return False, steps
+
+    args = [config.CERTBOT_BIN, "renew", "--cert-name", domain,
+            "--force-renewal", "--non-interactive", "--no-random-sleep-on-renew"]
+    res = nm.run_cmd("Renew Let's Encrypt certificate (certbot)", nm._privileged(args))
+    steps.append(res)
+    if not res["ok"]:
+        return False, steps
+
+    return _install_issued(domain, steps), steps
+
+
+def delete_certbot_data(domain):
+    """Best-effort cleanup of certbot's own bookkeeping for a cert (renewal
+    config, account reference, archive). Never blocks the registry delete."""
+    args = [config.CERTBOT_BIN, "delete", "--cert-name", domain, "-n"]
+    return nm.run_cmd("Remove Let's Encrypt certbot data", nm._privileged(args), allow_fail=True)
+
+
+# --------------------------------------------------------------------------
+# Auto-renewal scheduler (in-app, no system cron needed) — mirrors backup.py
+# --------------------------------------------------------------------------
+def _parse_openssl_date(s):
+    """'Nov 12 08:00:00 2026 GMT' -> aware UTC datetime."""
+    s = s.strip()
+    if s.endswith(" GMT"):
+        s = s[:-4]
+    return datetime.datetime.strptime(s, "%b %d %H:%M:%S %Y").replace(
+        tzinfo=datetime.timezone.utc)
+
+
+def _due_for_renewal(rec):
+    not_after = nm.cert_info(rec["name"]).get("not_after")
+    if not not_after:
+        return False   # cert file missing/unreadable — nothing to renew from
+    try:
+        expiry = _parse_openssl_date(not_after)
+    except ValueError:
+        return False
+    within = datetime.timedelta(days=config.LETSENCRYPT_RENEW_WITHIN_DAYS)
+    return expiry - datetime.datetime.now(datetime.timezone.utc) <= within
+
+
+def check_and_renew_all():
+    """Renew every Let's Encrypt cert that's due. Best-effort; never raises."""
+    for rec in storage.cert_list():
+        if rec.get("source") != "letsencrypt":
+            continue
+        try:
+            if not _due_for_renewal(rec):
+                continue
+            ok, _steps = renew_certificate(rec["name"], bind_ip=rec.get("bind_ip"))
+            if ok:
+                storage.cert_add({**rec, **nm.cert_info(rec["name"]), "renewed": _now()})
+        except Exception:
+            pass   # one bad cert must not stop the others
+
+
+def _now():
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+_scheduler_started = False
+
+
+def start_scheduler():
+    """Launch the daemon thread that renews due Let's Encrypt certs (idempotent)."""
+    global _scheduler_started
+    if _scheduler_started:
+        return
+    _scheduler_started = True
+
+    def _loop():
+        while True:
+            try:
+                check_and_renew_all()
+            except Exception:
+                pass
+            time.sleep(6 * 3600)   # renewal only fires within RENEW_WITHIN_DAYS anyway
+
+    threading.Thread(target=_loop, name="letsencrypt-renewal", daemon=True).start()

--- a/backend/validators.py
+++ b/backend/validators.py
@@ -23,6 +23,10 @@ _ACL_RESERVED = {"_default"}
 # 6 colon-separated hex octets.
 _MAC_RE = re.compile(r"^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$")
 
+# Deliberately permissive (not full RFC 5322) — good enough to catch typos
+# before it's handed to certbot for ACME account registration.
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
 
 def random_mac():
     """
@@ -76,6 +80,13 @@ def clean_domain(value):
     # Defence in depth: the domain becomes part of file paths.
     if "/" in value or ".." in value:
         raise ValidationError(f"Illegal characters in domain: {value!r}")
+    return value
+
+
+def clean_email(value):
+    value = (value or "").strip()
+    if not value or not _EMAIL_RE.match(value):
+        raise ValidationError(f"Invalid email address: {value!r}")
     return value
 
 

--- a/frontend/static/app.js
+++ b/frontend/static/app.js
@@ -2631,7 +2631,38 @@ function renderIfaceTree() {
 }
 
 // --- SSL management (certificate registry) ---------------------------------
+// Populate the Let's Encrypt card's HTTP-01 bind-IP select from the same
+// physical-interface / sub-interface data the mapping form's dropdown uses —
+// but keyed by IP (what the backend actually needs), not device name.
+function fillLeBindIpSelect() {
+  const sel = $("#ssl-le-bind-ip");
+  if (!sel) return;
+  const cur = sel.value;
+  const seen = new Set();
+  const opts = [];
+  (IFACES || []).forEach((i) => (i.addresses || []).forEach((a) => {
+    if (a.ip && !seen.has(a.ip)) { seen.add(a.ip); opts.push({ ip: a.ip, label: `${a.ip} · ${i.name}` }); }
+  }));
+  (SUBIFACES || []).forEach((s) => {
+    if (s.bind_ip && !seen.has(s.bind_ip)) {
+      seen.add(s.bind_ip);
+      opts.push({ ip: s.bind_ip, label: `${s.bind_ip} · ${s.name}${s.vlan_id ? " · vlan " + s.vlan_id : ""}` });
+    }
+  });
+  sel.innerHTML = opts.length
+    ? opts.map((o) => `<option value="${escapeHtml(o.ip)}">${escapeHtml(o.label)}</option>`).join("")
+    : '<option value="">no interfaces available</option>';
+  if (opts.some((o) => o.ip === cur)) sel.value = cur;
+}
+
+const SSL_SOURCE_BADGE = {
+  upload: '<span class="inline-block px-2 py-0.5 rounded-full bg-slate-100 text-slate-600 text-xs">uploaded</span>',
+  selfsigned: '<span class="inline-block px-2 py-0.5 rounded-full bg-indigo-100 text-indigo-700 text-xs">self-signed</span>',
+  letsencrypt: '<span class="inline-block px-2 py-0.5 rounded-full bg-sky-100 text-sky-700 text-xs">Let\'s Encrypt</span>',
+};
+
 async function loadSslCerts() {
+  fillLeBindIpSelect();
   try {
     const j = await (await fetch("/api/ssl/certs")).json();
     if (!j.ok) return;
@@ -2646,18 +2677,23 @@ async function loadSslCerts() {
       const tr = document.createElement("tr");
       tr.className = "hover:bg-slate-50 align-top";
       tr.style.setProperty("--i", Math.min(idx, 12));
-      const srcBadge = c.source === "upload"
-        ? '<span class="inline-block px-2 py-0.5 rounded-full bg-slate-100 text-slate-600 text-xs">uploaded</span>'
-        : '<span class="inline-block px-2 py-0.5 rounded-full bg-indigo-100 text-indigo-700 text-xs">self-signed</span>';
+      const srcBadge = SSL_SOURCE_BADGE[c.source] || SSL_SOURCE_BADGE.selfsigned;
+      const staging = c.staging
+        ? ' <span class="inline-block px-1.5 py-0.5 rounded bg-amber-100 text-amber-700 text-[10px] align-middle" title="Staging — untrusted test certificate">staging</span>'
+        : "";
       const inUse = c.in_use
         ? '<span class="text-xs text-emerald-700">● in use</span>'
         : '<span class="text-xs text-slate-400">unused</span>';
+      const renewBtn = c.source === "letsencrypt"
+        ? `<button data-cert="${escapeHtml(c.name)}" class="ssl-renew-btn text-xs font-medium text-sky-600 hover:text-sky-800 mr-3">Renew</button>`
+        : "";
       tr.innerHTML = `
         <td class="px-6 py-3 font-mono">${escapeHtml(c.name)}${c.subject ? `<div class="text-xs text-slate-400 font-sans">${escapeHtml(c.subject)}</div>` : ""}</td>
-        <td class="px-6 py-3">${srcBadge}</td>
+        <td class="px-6 py-3">${srcBadge}${staging}</td>
         <td class="px-6 py-3 text-xs text-slate-500">${c.not_after ? escapeHtml(c.not_after) : "—"}</td>
         <td class="px-6 py-3">${inUse}</td>
-        <td class="px-6 py-3 text-right">
+        <td class="px-6 py-3 text-right whitespace-nowrap">
+          ${renewBtn}
           <button data-cert="${escapeHtml(c.name)}" class="ssl-del-btn text-xs font-medium ${c.in_use ? "text-slate-300 cursor-not-allowed" : "text-red-600 hover:text-red-800"}" ${c.in_use ? "disabled" : ""}
             ${c.in_use ? 'title="In use by a mapping — detach it first"' : ""}>Delete</button>
         </td>`;
@@ -2665,6 +2701,8 @@ async function loadSslCerts() {
     });
     tb.querySelectorAll(".ssl-del-btn:not([disabled])").forEach((b) =>
       b.addEventListener("click", () => deleteCert(b.dataset.cert)));
+    tb.querySelectorAll(".ssl-renew-btn").forEach((b) =>
+      b.addEventListener("click", () => renewCert(b.dataset.cert)));
   } catch (_) { /* non-fatal */ }
 }
 
@@ -2672,12 +2710,18 @@ async function createCert(mode, form) {
   const fd = new FormData(form);
   fd.append("mode", mode);
   const btn = form.querySelector('button[type="submit"]');
-  setBtnLoading(btn, true, mode === "selfsigned" ? "Generating…" : "Adding…");
-  showStatus("loading", mode === "selfsigned" ? "Generating certificate…" : "Adding certificate…",
-             mode === "selfsigned" ? "Creating a self-signed cert + key on the host."
-                                   : "Validating and storing the uploaded cert + key.");
+  const labels = { selfsigned: "Generating…", letsencrypt: "Requesting…" };
+  setBtnLoading(btn, true, labels[mode] || "Adding…");
+  const loadingMsg = {
+    selfsigned: "Creating a self-signed cert + key on the host.",
+    letsencrypt: "Running certbot against Let's Encrypt (HTTP-01) — this can take up to a minute.",
+  };
+  showStatus("loading", mode === "letsencrypt" ? "Requesting certificate…"
+                        : mode === "selfsigned" ? "Generating certificate…" : "Adding certificate…",
+             loadingMsg[mode] || "Validating and storing the uploaded cert + key.");
   try {
     const j = await (await fetch("/api/ssl/certs", { method: "POST", body: fd })).json();
+    renderSteps(j.steps);
     if (j.ok) {
       showStatus("success", "Certificate added", `${j.cert.name} is ready to use.`);
       form.reset();
@@ -2690,6 +2734,14 @@ async function createCert(mode, form) {
   } finally {
     setBtnLoading(btn, false);
   }
+}
+
+async function renewCert(name) {
+  if (!confirm(`Renew the Let's Encrypt certificate for ${name} now?`)) return;
+  const j = await (await fetch(`/api/ssl/certs/${encodeURIComponent(name)}/renew`, { method: "POST" })).json();
+  renderSteps(j.steps);
+  if (j.ok) { toast(`${name} renewed — expires ${j.cert.not_after || "soon"}.`); await loadSslCerts(); }
+  else toast(j.error || "Renewal failed.", false);
 }
 
 async function deleteCert(name) {
@@ -4320,6 +4372,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   $("#si-bulk-delete").addEventListener("click", deleteSelectedSubifaces);
   $("#subiface-select").addEventListener("change", syncSubifaceBindIp);
   $("#ssl-refresh").addEventListener("click", loadSslCerts);
+  $("#ssl-le-form").addEventListener("submit", (e) => { e.preventDefault(); createCert("letsencrypt", e.target); });
   $("#ssl-selfsigned-form").addEventListener("submit", (e) => { e.preventDefault(); createCert("selfsigned", e.target); });
   $("#ssl-upload-form").addEventListener("submit", (e) => { e.preventDefault(); createCert("upload", e.target); });
 

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -734,6 +734,39 @@
           <div class="grid gap-6 lg:grid-cols-3">
             <!-- create -->
             <div class="lg:col-span-1 space-y-6">
+              <!-- let's encrypt -->
+              <div class="card bg-white/80 rounded-2xl shadow-sm border border-slate-200/70 p-6">
+                <h3 class="text-sm font-semibold mb-4">Let's Encrypt</h3>
+                <form id="ssl-le-form" class="space-y-3">
+                  <div>
+                    <label class="block text-xs font-medium mb-1">Domain</label>
+                    <input name="name" id="ssl-le-name" required placeholder="app.example.com"
+                      class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm font-mono outline-none focus:ring-2 focus:ring-emerald-500" />
+                  </div>
+                  <div>
+                    <label class="block text-xs font-medium mb-1">Extra domains <span class="text-slate-400 font-normal">(opt, comma-separated)</span></label>
+                    <input name="extra_domains" id="ssl-le-extra" placeholder="www.app.example.com"
+                      class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm font-mono outline-none focus:ring-2 focus:ring-emerald-500" />
+                  </div>
+                  <div>
+                    <label class="block text-xs font-medium mb-1">Email</label>
+                    <input name="email" id="ssl-le-email" type="email" required placeholder="you@example.com"
+                      class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-emerald-500" />
+                  </div>
+                  <div>
+                    <label class="block text-xs font-medium mb-1">HTTP-01 bind IP</label>
+                    <select name="bind_ip" id="ssl-le-bind-ip"
+                      class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm font-mono bg-white outline-none focus:ring-2 focus:ring-emerald-500"></select>
+                    <p class="mt-1 text-[10px] text-slate-400">The address this domain's DNS points at. Let's Encrypt must be able to reach it on port 80 for a few seconds.</p>
+                  </div>
+                  <label class="flex items-center gap-2 text-xs text-slate-600">
+                    <input type="checkbox" name="staging" id="ssl-le-staging" class="rounded border-slate-300" />
+                    Use staging (testing — untrusted certs, no rate limits)
+                  </label>
+                  <button type="submit" class="btn-primary w-full bg-gradient-to-br from-sky-500 to-sky-600 hover:from-sky-600 hover:to-sky-700 text-white text-sm font-semibold rounded-xl px-4 py-2.5 shadow-lg shadow-sky-600/25">Request certificate</button>
+                </form>
+              </div>
+
               <!-- self-signed -->
               <div class="card bg-white/80 rounded-2xl shadow-sm border border-slate-200/70 p-6">
                 <h3 class="text-sm font-semibold mb-4">Generate self-signed</h3>

--- a/setup.sh
+++ b/setup.sh
@@ -119,19 +119,19 @@ install_deps() {
       apt-get update -qq
       apt-get install -y --no-install-recommends \
         nginx libnginx-mod-stream python3 python3-venv \
-        iproute2 isc-dhcp-client openssl iptables \
+        iproute2 isc-dhcp-client openssl iptables certbot \
         iputils-ping traceroute tcpdump whois dnsutils net-tools
       ;;
     dnf|yum)
-      "$PM" install -y nginx python3 iproute openssl iptables || true
+      "$PM" install -y nginx python3 iproute openssl iptables certbot || true
       "$PM" install -y nginx-mod-stream || c_y "nginx-mod-stream not found — your nginx may already include stream."
       "$PM" install -y dhcp-client || "$PM" install -y dhclient || c_y "no dhcp client (DHCP allocation will be unavailable)."
       "$PM" install -y iputils traceroute tcpdump whois bind-utils net-tools || \
         c_y "Some diagnostic tools could not be installed — Tools page features may be limited."
       ;;
     pacman)
-      pacman -Sy --noconfirm nginx-mainline python iproute2 openssl || \
-        pacman -Sy --noconfirm nginx python iproute2 openssl
+      pacman -Sy --noconfirm nginx-mainline python iproute2 openssl certbot || \
+        pacman -Sy --noconfirm nginx python iproute2 openssl certbot
       pacman -Sy --noconfirm dhclient || c_y "no dhcp client (DHCP allocation unavailable)."
       pacman -Sy --noconfirm iptables-nft || pacman -Sy --noconfirm iptables || \
         c_y "iptables not installed — the Firewall page will be unavailable."
@@ -139,12 +139,12 @@ install_deps() {
         c_y "Some diagnostic tools could not be installed — Tools page features may be limited."
       ;;
     zypper)
-      zypper --non-interactive install nginx python3 iproute2 openssl dhcp-client iptables || true
+      zypper --non-interactive install nginx python3 iproute2 openssl dhcp-client iptables certbot || true
       zypper --non-interactive install iputils traceroute tcpdump whois bind-utils net-tools || \
         c_y "Some diagnostic tools could not be installed — Tools page features may be limited."
       ;;
     "")
-      c_y "No known package manager detected — install manually: nginx(+stream), python3+venv, iproute2, a dhcp client, openssl, iptables."
+      c_y "No known package manager detected — install manually: nginx(+stream), python3+venv, iproute2, a dhcp client, openssl, iptables, certbot."
       c_y "Also install for the Tools page: iputils, traceroute, tcpdump, whois, bind-utils (or dnsutils), net-tools."
       ;;
   esac
@@ -162,6 +162,8 @@ check_tools() {
   fi
   command -v iptables >/dev/null 2>&1 && c_g "  [ok] iptables" || \
     c_y "  [missing] iptables — the Firewall page will be unavailable."
+  command -v certbot >/dev/null 2>&1 && c_g "  [ok] certbot" || \
+    c_y "  [missing] certbot — the SSL page's Let's Encrypt option will be unavailable."
 }
 [ "$DO_DEPS" = "1" ] && install_deps || c_y "Skipping dependency install (--no-deps)."
 


### PR DESCRIPTION
HTTP-01 challenge using certbot --standalone bound to the mapping's own IP:80, so no nginx webroot config is needed — issued certs land in SSL_DIR alongside uploaded/self-signed ones and are usable everywhere unchanged. Adds request/renew/delete API routes, an SSL-page UI card, a background auto-renewal thread for certs nearing expiry, and installs certbot in the Docker image and setup.sh. Approach borrows the HTTP-01 flow from nginx-proxy-manager's certbot.js, adapted for Splitter's L4-proxy model.